### PR TITLE
Accomodate updated QRImage factory init method.

### DIFF
--- a/jparty/welcome_widget.py
+++ b/jparty/welcome_widget.py
@@ -25,7 +25,7 @@ from jparty.style import WINDOWPAL
 class QRImage(qrcode.image.base.BaseImage):
     """QR code image widget"""
 
-    def __init__(self, border, width, box_size):
+    def __init__(self, border, width, box_size, qrcode_modules):
         self.border = border
         self.width = width
         self.box_size = box_size


### PR DESCRIPTION
Without this change, game crashes immediately with the following exception:
TypeError: QRImage.__init__() got an unexpected keyword argument 'qrcode_modules'
